### PR TITLE
Point to latest remark and Style to match v0.6.3

### DIFF
--- a/slides.html
+++ b/slides.html
@@ -1031,7 +1031,7 @@ This presentation was updated by Jules David ([@galactics](https://github.com/ga
 on march 2016, to include some changes brought by Python 3.5.
 
 </textarea>
-    <script src="https://gnab.github.io/remark/downloads/remark-latest.min.js" type="text/javascript">
+    <script src="https://cdn.rawgit.com/gnab/remark/gh-pages/downloads/remark-latest.min.js" type="text/javascript">
     </script>
     <!-- Uncomment this if there is no internet -->
 

--- a/slides.html
+++ b/slides.html
@@ -5,6 +5,11 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <style type="text/css">
       /* Slideshow styles */
+	  .remark-slide-content { font-size: 1em; }
+	  .remark-slide-content h1 { font-size: 2em; }
+	  .remark-slide-content h2 { font-size: 1.5em; }
+	  .remark-slide-content h3 { font-size: 1.17em; }
+	  .remark-code { font-size: 1em; }
     </style>
   </head>
   <body>
@@ -1026,7 +1031,7 @@ This presentation was updated by Jules David ([@galactics](https://github.com/ga
 on march 2016, to include some changes brought by Python 3.5.
 
 </textarea>
-    <script src="https://gnab.github.io/remark/downloads/remark-0.6.3.min.js" type="text/javascript">
+    <script src="https://gnab.github.io/remark/downloads/remark-latest.min.js" type="text/javascript">
     </script>
     <!-- Uncomment this if there is no internet -->
 


### PR DESCRIPTION
### Background for Pull request

Pages, including your blog at: http://asmeurer.github.io/blog/work/ for instance point towards your python3 presentation via an https link. 
When viewing this on my recent Chrome/Firefox versions the presentation does not render. 

Inspecting the source using Chrome's Developer Tools shows an error _Mixed content: (...) requested insecure script http://remarkjs.com/downloads/remark-0.6.3.min.js_.
This is obviously a redirect from the address used in your source, namely: https://gnab.github.io/remark/downloads/remark-0.6.3.min.js

A simple change to the latest version of of `remark` as recommended on remarks page renders text too large, as noted in your own commit SHA: 3cd903f4013689bb4e93cb9aa15a48ffcff0f898 

This pull request again points towards the latest of `remark`, but adds styling to bring the original font sizes for headers, code etc back so that it is rendered correctly (at least in my tests).
