### PR TITLE
Point to remarkjs.com now that https enforced

### DIFF
--- a/slides.html
+++ b/slides.html
@@ -1026,7 +1026,7 @@ This presentation was updated by Jules David ([@galactics](https://github.com/ga
 on march 2016, to include some changes brought by Python 3.5.
 
 </textarea>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript">
+    <script src="https://remarkjs.com/downloads/remark-0.6.3.min.js" type="text/javascript">
     </script>
     <!-- Uncomment this if there is no internet -->
 

--- a/slides.html
+++ b/slides.html
@@ -1026,7 +1026,7 @@ This presentation was updated by Jules David ([@galactics](https://github.com/ga
 on march 2016, to include some changes brought by Python 3.5.
 
 </textarea>
-    <script src="https://cdn.rawgit.com/gnab/remark/gh-pages/downloads/remark-0.6.3.min.js" type="text/javascript">
+    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript">
     </script>
     <!-- Uncomment this if there is no internet -->
 


### PR DESCRIPTION
## Details

Replace the previous workaround with a direct link to remarkjs.com.

The https issue (redirecting to http) that necessitated the workaround in the first place has been fixed upstream by gnab, see remark issue https://github.com/gnab/remark/issues/340.

Another option would be to change the link to the github.io pages: ie https://gnab.github.io/remark/downloads/remark-0.6.3.min.js - but as it redirects to remarkjs.com I decided to go this route.
